### PR TITLE
Documentation Update for Cache Location on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ The performance characteristics of the generated self-contained application is r
 
 ### Packages cache location
 - Linux: `$HOME/.local/share/warp/packages`
-- macOS: `$HOME/Library/Application Support/warp/packges`
+- macOS: `$HOME/Library/Application Support/warp/packages`
 - Windows: `%LOCALAPPDATA%\warp\packages`
 
 ### Runners cache location


### PR DESCRIPTION
This threw me a bit, as I copied and pasted trying to clear the cache on macOS and this path was wrong.

Would be really great to make this cache based on a hash or version somehow. 