### PR TITLE
Environment variable to executable

### DIFF
--- a/warp-packer/src/main.rs
+++ b/warp-packer/src/main.rs
@@ -116,7 +116,7 @@ fn create_app(runner_buf: &Vec<u8>, tgz_path: &Path, out: &Path) -> io::Result<(
     Ok(())
 }
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let args = App::new(APP_NAME)
         .settings(&[AppSettings::ArgRequiredElseHelp, AppSettings::ColoredHelp])
         .version(VERSION)

--- a/warp-runner/src/main.rs
+++ b/warp-runner/src/main.rs
@@ -43,7 +43,7 @@ fn extract(exe_path: &Path, cache_path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     if env::var("WARP_TRACE").is_ok() {
         simple_logger::init_with_level(Level::Trace)?;
     }


### PR DESCRIPTION
- Added an environment variable (WARP_EXEC_PATH) which contains the path to the executable file
- Changed the ensure_executable() since it overwrote the file permissions with 770. The new function keeps the file permissions and adds the executable flag.
- Added support for vbs scripts